### PR TITLE
Disable Key Recovery; Add InfoDialog

### DIFF
--- a/lib/app/pages/on_boarding/gen.dart
+++ b/lib/app/pages/on_boarding/gen.dart
@@ -1,4 +1,3 @@
-import 'package:bip39/bip39.dart' as bip39;
 import 'package:credible/app/shared/palette.dart';
 import 'package:credible/app/shared/widget/base/page.dart';
 import 'package:credible/localizations.dart';
@@ -22,11 +21,10 @@ class _OnBoardingGenPageState extends State<OnBoardingGenPage> {
 
   Future<void> generateKey() async {
     final storage = FlutterSecureStorage();
-    final mnemonic = await storage.read(key: 'mnemonic');
-    final entropy = bip39.mnemonicToSeedHex(mnemonic);
-    // final key = await DIDKit.generateEd25519KeyFromSecret(entropy.substring(0, 32));
 
-    // print(key);
+    // final mnemonic = await storage.read(key: 'mnemonic');
+    // final entropy = bip39.mnemonicToSeedHex(mnemonic);
+    // final key = await DIDKit.generateEd25519KeyFromSecret(entropy.substring(0, 32));
 
     final key = await DIDKit.generateEd25519Key();
 

--- a/lib/app/pages/on_boarding/key.dart
+++ b/lib/app/pages/on_boarding/key.dart
@@ -1,5 +1,6 @@
 import 'package:credible/app/shared/widget/base/button.dart';
 import 'package:credible/app/shared/widget/base/page.dart';
+import 'package:credible/app/shared/widget/info_dialog.dart';
 import 'package:credible/localizations.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
@@ -45,7 +46,13 @@ class OnBoardingKeyPage extends StatelessWidget {
                 const SizedBox(height: 32.0),
                 BaseButton.blue(
                   onPressed: () {
-                    Modular.to.pushNamed('/on-boarding/recovery');
+                    showDialog(
+                      context: context,
+                      builder: (context) => InfoDialog(
+                        title: 'Unavailable Feature',
+                        subtitle: "This feature isn't supported yet",
+                      ),
+                    );
                   },
                   child: Text(localizations.onBoardingKeyRecover),
                 ),
@@ -71,7 +78,7 @@ class OnBoardingKeyPage extends StatelessWidget {
                 const SizedBox(height: 32.0),
                 BaseButton.blue(
                   onPressed: () {
-                    Modular.to.pushNamed('/on-boarding/gen-phrase');
+                    Modular.to.pushNamed('/on-boarding/gen');
                   },
                   child: Text(localizations.onBoardingKeyGenerate),
                 ),

--- a/lib/app/pages/profile/profile.dart
+++ b/lib/app/pages/profile/profile.dart
@@ -5,6 +5,7 @@ import 'package:credible/app/pages/profile/widgets/did_display.dart';
 import 'package:credible/app/pages/profile/widgets/menu_item.dart';
 import 'package:credible/app/shared/palette.dart';
 import 'package:credible/app/shared/widget/base/page.dart';
+import 'package:credible/app/shared/widget/info_dialog.dart';
 import 'package:credible/app/shared/widget/navigation_bar.dart';
 import 'package:credible/localizations.dart';
 import 'package:didkit/didkit.dart';
@@ -97,7 +98,15 @@ class _ProfilePageState extends State<ProfilePage> {
               MenuItem(
                 icon: Icons.vpn_key,
                 title: 'Recovery',
-                onTap: () => Modular.to.pushNamed('/profile/recovery'),
+                onTap: () {
+                  showDialog(
+                    context: context,
+                    builder: (context) => InfoDialog(
+                      title: 'Unavailable Feature',
+                      subtitle: "This feature isn't supported yet",
+                    ),
+                  );
+                },
               ),
               MenuItem(
                 icon: Icons.support,

--- a/lib/app/pages/qr_code/scan.dart
+++ b/lib/app/pages/qr_code/scan.dart
@@ -100,7 +100,6 @@ class _QrCodeScanPageState extends ModularState<QrCodeScanPage, QRCodeBloc> {
           ));
         }
         if (state is QRCodeStateHost) {
-          print('how many times');
           promptHost(state.uri);
         }
         if (state is QRCodeStateUnknown) {

--- a/lib/app/shared/widget/info_dialog.dart
+++ b/lib/app/shared/widget/info_dialog.dart
@@ -1,0 +1,50 @@
+import 'package:credible/app/shared/widget/base/button.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_modular/flutter_modular.dart';
+
+class InfoDialog extends StatelessWidget {
+  final String title;
+  final String? subtitle;
+  final String button;
+
+  const InfoDialog({
+    Key? key,
+    required this.title,
+    this.subtitle,
+    this.button = 'Ok',
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      contentPadding: const EdgeInsets.only(
+        top: 24.0,
+        bottom: 16.0,
+        left: 24.0,
+        right: 24.0,
+      ),
+      title: Text(
+        title,
+        style: Theme.of(context).textTheme.subtitle1,
+      ),
+      content: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          if (subtitle != null)
+            Text(
+              subtitle!,
+              style: Theme.of(context).textTheme.bodyText1,
+            ),
+          const SizedBox(height: 24.0),
+          BaseButton.blue(
+            onPressed: () {
+              Modular.to.pop();
+            },
+            child: Text(button),
+          ),
+        ],
+      ),
+    );
+  }
+}


### PR DESCRIPTION
When the user clicks the Recovery option in both on-boarding and profile pages, they will be shown a notification that the feature is currently unavailable;
When the user clicks the Generate option in on-boarding they will skip the mnemonic page;
Add InfoDialog widget to show the previously mentioned notifications;