### PR TITLE
Add Key Recovery feature

### DIFF
--- a/lib/app/pages/on_boarding/gen_phrase.dart
+++ b/lib/app/pages/on_boarding/gen_phrase.dart
@@ -58,7 +58,6 @@ class _OnBoardingGenPhrasePageState extends State<OnBoardingGenPhrasePage> {
               ],
             ),
           ),
-          const SizedBox(height: 32.0),
           Expanded(
             child: Wrap(
               spacing: 16.0,
@@ -71,9 +70,11 @@ class _OnBoardingGenPhrasePageState extends State<OnBoardingGenPhrasePage> {
               ),
             ),
           ),
-          const SizedBox(height: 32.0),
           Padding(
-            padding: const EdgeInsets.symmetric(horizontal: 16.0),
+            padding: const EdgeInsets.symmetric(
+              horizontal: 16.0,
+              vertical: 24.0,
+            ),
             child: Row(
               children: <Widget>[
                 Icon(
@@ -93,7 +94,6 @@ class _OnBoardingGenPhrasePageState extends State<OnBoardingGenPhrasePage> {
               ],
             ),
           ),
-          const SizedBox(height: 48.0),
           BaseButton.blue(
             onPressed: () async {
               await SecureStorageProvider.instance.set(

--- a/lib/app/pages/on_boarding/key.dart
+++ b/lib/app/pages/on_boarding/key.dart
@@ -1,6 +1,5 @@
 import 'package:credible/app/shared/widget/base/button.dart';
 import 'package:credible/app/shared/widget/base/page.dart';
-import 'package:credible/app/shared/widget/info_dialog.dart';
 import 'package:credible/localizations.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
@@ -23,7 +22,7 @@ class OnBoardingKeyPage extends StatelessWidget {
               vertical: 48.0,
             ),
             child: Text(
-              'Choose how you want to add your key',
+              'Recover my identity wallet',
               textAlign: TextAlign.center,
               style: Theme.of(context).textTheme.subtitle1,
             ),
@@ -38,7 +37,7 @@ class OnBoardingKeyPage extends StatelessWidget {
                     horizontal: 48.0,
                   ),
                   child: Text(
-                    'If you have previously used a wallet and have a recovery phrase, press "Recover"',
+                    'If you have previously used a wallet and have a recovery phrase',
                     textAlign: TextAlign.center,
                     style: Theme.of(context).textTheme.bodyText1,
                   ),
@@ -46,13 +45,7 @@ class OnBoardingKeyPage extends StatelessWidget {
                 const SizedBox(height: 32.0),
                 BaseButton.blue(
                   onPressed: () {
-                    showDialog(
-                      context: context,
-                      builder: (context) => InfoDialog(
-                        title: 'Unavailable Feature',
-                        subtitle: "This feature isn't supported yet",
-                      ),
-                    );
+                    Modular.to.pushNamed('/on-boarding/recovery');
                   },
                   child: Text(localizations.onBoardingKeyRecover),
                 ),
@@ -60,6 +53,17 @@ class OnBoardingKeyPage extends StatelessWidget {
             ),
           ),
           const SizedBox(height: 64.0),
+          Padding(
+            padding: const EdgeInsets.symmetric(
+              horizontal: 16.0,
+              vertical: 48.0,
+            ),
+            child: Text(
+              'Generate a new wallet',
+              textAlign: TextAlign.center,
+              style: Theme.of(context).textTheme.subtitle1,
+            ),
+          ),
           Expanded(
             child: Column(
               mainAxisAlignment: MainAxisAlignment.center,
@@ -70,7 +74,7 @@ class OnBoardingKeyPage extends StatelessWidget {
                     horizontal: 48.0,
                   ),
                   child: Text(
-                    'Otherwise you can generate your first identifier by pressing "Generate"',
+                    'Generate a new identifier and get a new recovery phrase',
                     textAlign: TextAlign.center,
                     style: Theme.of(context).textTheme.bodyText1,
                   ),
@@ -78,7 +82,7 @@ class OnBoardingKeyPage extends StatelessWidget {
                 const SizedBox(height: 32.0),
                 BaseButton.blue(
                   onPressed: () {
-                    Modular.to.pushNamed('/on-boarding/gen');
+                    Modular.to.pushNamed('/on-boarding/gen-phrase');
                   },
                   child: Text(localizations.onBoardingKeyGenerate),
                 ),

--- a/lib/app/pages/on_boarding/recovery.dart
+++ b/lib/app/pages/on_boarding/recovery.dart
@@ -25,6 +25,7 @@ class OnBoardingRecoveryPage extends StatefulWidget {
 class _OnBoardingRecoveryPageState extends State<OnBoardingRecoveryPage> {
   late TextEditingController mnemonicController;
   late bool buttonEnabled;
+  late bool edited;
 
   @override
   void initState() {
@@ -33,10 +34,12 @@ class _OnBoardingRecoveryPageState extends State<OnBoardingRecoveryPage> {
     mnemonicController = TextEditingController();
     mnemonicController.addListener(() {
       setState(() {
+        edited = mnemonicController.text.isNotEmpty;
         buttonEnabled = bip39.validateMnemonic(mnemonicController.text);
       });
     });
 
+    edited = false;
     buttonEnabled = false;
   }
 
@@ -50,25 +53,22 @@ class _OnBoardingRecoveryPageState extends State<OnBoardingRecoveryPage> {
       scrollView: false,
       padding: EdgeInsets.zero,
       body: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
         crossAxisAlignment: CrossAxisAlignment.stretch,
         children: <Widget>[
           const SizedBox(height: 32.0),
           OnBoardingRecoveryPage._padHorizontal(Text(
-            'Write the recovery phrase in the given order',
+            'Please enter your recovery phrase',
             textAlign: TextAlign.center,
             style: Theme.of(context).textTheme.subtitle1,
           )),
           const SizedBox(height: 24.0),
-          Expanded(
-            child: Center(
-              child: BaseTextField(
-                label: 'Mnemonic Phrase',
-                controller: mnemonicController,
-                error: !buttonEnabled
-                    ? 'Please enter a valid mnemonic phrase'
-                    : null,
-              ),
-            ),
+          BaseTextField(
+            label: 'Mnemonic Phrase',
+            controller: mnemonicController,
+            error: edited && !buttonEnabled
+                ? 'Please enter a valid mnemonic phrase'
+                : null,
           ),
           const SizedBox(height: 24.0),
           OnBoardingRecoveryPage._padHorizontal(BaseButton.blue(

--- a/lib/app/pages/profile/profile.dart
+++ b/lib/app/pages/profile/profile.dart
@@ -9,7 +9,6 @@ import 'package:credible/app/pages/profile/widgets/menu_item.dart';
 import 'package:credible/app/shared/palette.dart';
 import 'package:credible/app/shared/widget/base/page.dart';
 import 'package:credible/app/shared/widget/confirm_dialog.dart';
-import 'package:credible/app/shared/widget/info_dialog.dart';
 import 'package:credible/app/shared/widget/navigation_bar.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';

--- a/lib/app/pages/profile/profile.dart
+++ b/lib/app/pages/profile/profile.dart
@@ -98,14 +98,25 @@ class _ProfilePageState extends State<ProfilePage> {
               MenuItem(
                 icon: Icons.vpn_key,
                 title: 'Recovery',
-                onTap: () {
-                  showDialog(
-                    context: context,
-                    builder: (context) => InfoDialog(
-                      title: 'Unavailable Feature',
-                      subtitle: "This feature isn't supported yet",
-                    ),
-                  );
+                onTap: () async {
+                  final confirm = await showDialog<bool>(
+                        context: context,
+                        builder: (context) => ConfirmDialog(
+                          title: 'Be careful',
+                          subtitle:
+                              'The recovery page contains sensitive information '
+                              'that will compromise your identifier in the wrong '
+                              'hands. You should not open this page in public '
+                              'or share it with anyone.',
+                          yes: 'Continue',
+                          no: 'Cancel',
+                        ),
+                      ) ??
+                      false;
+
+                  if (confirm) {
+                    await Modular.to.pushNamed('/profile/recovery');
+                  }
                 },
               ),
               MenuItem(

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -66,6 +66,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "3.0.0-nullsafety.0"
+  cryptography:
+    dependency: transitive
+    description:
+      name: cryptography
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.0-nullsafety.2"
   cupertino_icons:
     dependency: "direct main"
     description:
@@ -94,6 +101,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "3.0.10"
+  ed25519_hd_key:
+    dependency: "direct main"
+    description:
+      path: "../dart-ed25519-hd-key"
+      relative: true
+    source: path
+    version: "1.1.0"
   fake_async:
     dependency: transitive
     description:
@@ -115,6 +129,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "6.0.0-nullsafety.4"
+  fixnum:
+    dependency: transitive
+    description:
+      name: fixnum
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.0"
   flutter:
     dependency: "direct main"
     description: flutter

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -14,7 +14,7 @@ packages:
       path: "."
       ref: nullsafety
       resolved-ref: "55242396a50991f9199803bd7aa4440eac0462f6"
-      url: "https://github.com/theosirian/bip39"
+      url: "https://github.com/spruceid/dart-bip39"
     source: git
     version: "1.0.4"
   bloc:
@@ -104,9 +104,11 @@ packages:
   ed25519_hd_key:
     dependency: "direct main"
     description:
-      path: "../dart-ed25519-hd-key"
-      relative: true
-    source: path
+      path: "."
+      ref: nullsafety
+      resolved-ref: "1e5bd2331e04bd2bff4fb456d77d829997a16afe"
+      url: "https://github.com/spruceid/dart-ed25519-hd-key"
+    source: git
     version: "1.1.0"
   fake_async:
     dependency: transitive

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -39,9 +39,14 @@ dependencies:
 
   js: ^0.6.3
 
+  ed25519_hd_key:
+    git:
+      url: https://github.com/spruceid/dart-ed25519-hd-key
+      ref: nullsafety
+
   bip39:
     git:
-      url: https://github.com/theosirian/bip39
+      url: https://github.com/spruceid/bip39
       ref: nullsafety
 
   didkit:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -46,7 +46,7 @@ dependencies:
 
   bip39:
     git:
-      url: https://github.com/spruceid/bip39
+      url: https://github.com/spruceid/dart-bip39
       ref: nullsafety
 
   didkit:


### PR DESCRIPTION
Adds Key Recovery feature using [`dart-ed25519-hd-key`](https://github.com/spruceid/dart-ed25519-hd-key) and [`dart-bip39`](https://github.com/spruceid/dart-bip39) vendored dependecies, which were changed to support nullsafety and be compatible with the current Credible dependencies.

Adds a confirmation dialog to enter the key recovery page on the profile page to avoid showing sensitive information by mistake.

Also included are a couple of UI fixes for the Recovery Pages.
- Fix OnBoarding Recovery Page text and validation
- Fix OnBoarding GenPhrase Page spacing
- Fix OnBoarding KeyPage text

Depends on #34.