### PR TITLE
Remove `DIDKitProvider.keyToDIDKey`

### DIFF
--- a/lib/app/interop/didkit/didkit.dart
+++ b/lib/app/interop/didkit/didkit.dart
@@ -14,9 +14,6 @@ abstract class DIDKitProvider {
 
   String generateEd25519Key();
 
-  @Deprecated('Use [keyToDID]')
-  String keyToDIDKey(String key);
-
   String keyToDID(String methodName, String key);
 
   String keyToVerificationMethod(String methodName, String key);

--- a/lib/app/interop/didkit/didkit_io.dart
+++ b/lib/app/interop/didkit/didkit_io.dart
@@ -23,11 +23,6 @@ class DIDKitIO extends DIDKitProvider {
   }
 
   @override
-  String keyToDIDKey(String key) {
-    return DIDKit.keyToDIDKey(key);
-  }
-
-  @override
   String keyToVerificationMethod(String methodName, String key) {
     return DIDKit.keyToVerificationMethod(methodName, key);
   }

--- a/lib/app/interop/didkit/didkit_js.dart
+++ b/lib/app/interop/didkit/didkit_js.dart
@@ -52,11 +52,6 @@ class DIDKitWeb extends DIDKitProvider {
   }
 
   @override
-  String keyToDIDKey(String key) {
-    return DIDKitJS.keyToDIDKey(key);
-  }
-
-  @override
   String keyToVerificationMethod(String methodName, String key) {
     return DIDKitJS.keyToVerificationMethod(methodName, key);
   }


### PR DESCRIPTION
Removes `DIDKitProvider.keyToDIDKey` to avoid lint issues.

Fixes #38 