### PR TITLE
Use Stable Rust on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,7 +75,7 @@ jobs:
     - name: SETUP | Rust
       uses: ATiltedTree/setup-rust@v1
       with:
-        rust-version: nightly
+        rust-version: stable
   
     - name: DIDKIT | rustup android
       working-directory: ./didkit


### PR DESCRIPTION
Changes CI to use stable Rust, following https://github.com/spruceid/didkit/pull/79.