### PR TITLE
Add Future/Promise support to DIDKit interface

### DIFF
--- a/lib/app/interop/didkit/didkit.dart
+++ b/lib/app/interop/didkit/didkit.dart
@@ -16,17 +16,43 @@ abstract class DIDKitProvider {
 
   String keyToDID(String methodName, String key);
 
-  String keyToVerificationMethod(String methodName, String key);
+  Future<String> keyToVerificationMethod(String methodName, String key);
 
-  String issueCredential(String credential, String options, String key);
+  Future<String> issueCredential(
+    String credential,
+    String options,
+    String key,
+  );
 
-  String verifyCredential(String credential, String options);
+  Future<String> verifyCredential(
+    String credential,
+    String options,
+  );
 
-  String issuePresentation(String presentation, String options, String key);
+  Future<String> issuePresentation(
+    String presentation,
+    String options,
+    String key,
+  );
 
-  String verifyPresentation(String presentation, String options);
+  Future<String> verifyPresentation(
+    String presentation,
+    String options,
+  );
 
-  String resolveDID(String did, String inputMetadata);
+  Future<String> resolveDID(
+    String did,
+    String inputMetadata,
+  );
 
-  String dereferenceDIDURL(String didUrl, String inputMetadata);
+  Future<String> dereferenceDIDURL(
+    String didUrl,
+    String inputMetadata,
+  );
+
+  Future<String> DIDAuth(
+    String did,
+    String options,
+    String key,
+  );
 }

--- a/lib/app/interop/didkit/didkit_io.dart
+++ b/lib/app/interop/didkit/didkit_io.dart
@@ -23,37 +23,66 @@ class DIDKitIO extends DIDKitProvider {
   }
 
   @override
-  String keyToVerificationMethod(String methodName, String key) {
+  Future<String> keyToVerificationMethod(String methodName, String key) async {
     return DIDKit.keyToVerificationMethod(methodName, key);
   }
 
   @override
-  String issueCredential(String credential, String options, String key) {
+  Future<String> issueCredential(
+    String credential,
+    String options,
+    String key,
+  ) async {
     return DIDKit.issueCredential(credential, options, key);
   }
 
   @override
-  String verifyCredential(String credential, String options) {
+  Future<String> verifyCredential(
+    String credential,
+    String options,
+  ) async {
     return DIDKit.verifyCredential(credential, options);
   }
 
   @override
-  String issuePresentation(String presentation, String options, String key) {
+  Future<String> issuePresentation(
+    String presentation,
+    String options,
+    String key,
+  ) async {
     return DIDKit.issuePresentation(presentation, options, key);
   }
 
   @override
-  String verifyPresentation(String presentation, String options) {
+  Future<String> verifyPresentation(
+    String presentation,
+    String options,
+  ) async {
     return DIDKit.verifyPresentation(presentation, options);
   }
 
   @override
-  String resolveDID(String did, String inputMetadata) {
+  Future<String> resolveDID(
+    String did,
+    String inputMetadata,
+  ) async {
     return DIDKit.resolveDID(did, inputMetadata);
   }
 
   @override
-  String dereferenceDIDURL(String didUrl, String inputMetadata) {
+  Future<String> dereferenceDIDURL(
+    String didUrl,
+    String inputMetadata,
+  ) async {
     return DIDKit.dereferenceDIDURL(didUrl, inputMetadata);
+  }
+
+  @override
+  Future<String> DIDAuth(
+    String did,
+    String options,
+    String key,
+  ) async {
+    return DIDKit.DIDAuth(did, options, key);
   }
 }

--- a/lib/app/interop/didkit/didkit_js.dart
+++ b/lib/app/interop/didkit/didkit_js.dart
@@ -2,87 +2,170 @@
 library didkit;
 
 import 'package:js/js.dart';
+import 'package:js/js_util.dart';
 
 import 'didkit.dart';
 
 DIDKitProvider getProvider() => DIDKitWeb();
 
-@JS('DIDKit')
-class DIDKitJS {
-  external static String getVersion();
+@JS('window.DIDKit.getVersion')
+external String _getVersion();
 
-  external static String generateEd25519Key();
+@JS('window.DIDKit.generateEd25519Key')
+external String _generateEd25519Key();
 
-  external static String keyToDID(String methodName, String key);
+@JS('window.DIDKit.keyToDID')
+external String _keyToDID(String methodName, String key);
 
-  external static String keyToDIDKey(String key);
+@JS('window.DIDKit.keyToVerificationMethod')
+external String _keyToVerificationMethod(String methodName, String key);
 
-  external static String keyToVerificationMethod(String methodName, String key);
+@JS('window.DIDKit.issueCredential')
+external String _issueCredential(
+  String credential,
+  String options,
+  String key,
+);
 
-  external static String issueCredential(
-      String credential, String options, String key);
+@JS('window.DIDKit.verifyCredential')
+external String _verifyCredential(
+  String credential,
+  String options,
+);
 
-  external static String verifyCredential(String credential, String options);
+@JS('window.DIDKit.issuePresentation')
+external String _issuePresentation(
+  String presentation,
+  String options,
+  String key,
+);
 
-  external static String issuePresentation(
-      String presentation, String options, String key);
+@JS('window.DIDKit.verifyPresentation')
+external String _verifyPresentation(
+  String presentation,
+  String options,
+);
 
-  external static String verifyPresentation(
-      String presentation, String options);
+@JS('window.DIDKit.resolveDID')
+external String _resolveDID(
+  String did,
+  String inputMetadata,
+);
 
-  external static String resolveDID(String did, String inputMetadata);
+@JS('window.DIDKit.dereferenceDIDURL')
+external String _dereferenceDIDURL(
+  String didUrl,
+  String inputMetadata,
+);
 
-  external static String dereferenceDIDURL(String didUrl, String inputMetadata);
-}
+@JS('window.DIDKit.DIDAuth')
+external String _DIDAuth(
+  String did,
+  String options,
+  String key,
+);
 
 class DIDKitWeb extends DIDKitProvider {
   @override
   String getVersion() {
-    return DIDKitJS.getVersion();
+    return _getVersion();
   }
 
   @override
   String generateEd25519Key() {
-    return DIDKitJS.generateEd25519Key();
+    return _generateEd25519Key();
   }
 
   @override
   String keyToDID(String methodName, String key) {
-    return DIDKitJS.keyToDID(methodName, key);
+    return _keyToDID(methodName, key);
   }
 
   @override
-  String keyToVerificationMethod(String methodName, String key) {
-    return DIDKitJS.keyToVerificationMethod(methodName, key);
+  Future<String> keyToVerificationMethod(String methodName, String key) async {
+    return await promiseToFuture(_keyToVerificationMethod(methodName, key));
   }
 
   @override
-  String issueCredential(String credential, String options, String key) {
-    return DIDKitJS.issueCredential(credential, options, key);
+  Future<String> issueCredential(
+    String credential,
+    String options,
+    String key,
+  ) async {
+    return await promiseToFuture(_issueCredential(
+      credential,
+      options,
+      key,
+    ));
   }
 
   @override
-  String verifyCredential(String credential, String options) {
-    return DIDKitJS.verifyCredential(credential, options);
+  Future<String> verifyCredential(
+    String credential,
+    String options,
+  ) async {
+    return await promiseToFuture(_verifyCredential(
+      credential,
+      options,
+    ));
   }
 
   @override
-  String issuePresentation(String presentation, String options, String key) {
-    return DIDKitJS.issuePresentation(presentation, options, key);
+  Future<String> issuePresentation(
+    String presentation,
+    String options,
+    String key,
+  ) async {
+    return await promiseToFuture(_issuePresentation(
+      presentation,
+      options,
+      key,
+    ));
   }
 
   @override
-  String verifyPresentation(String presentation, String options) {
-    return DIDKitJS.verifyPresentation(presentation, options);
+  Future<String> verifyPresentation(
+    String presentation,
+    String options,
+  ) async {
+    return await promiseToFuture(_verifyPresentation(
+      presentation,
+      options,
+    ));
   }
 
   @override
-  String resolveDID(String did, String inputMetadata) {
-    return DIDKitJS.resolveDID(did, inputMetadata);
+  Future<String> resolveDID(
+    String did,
+    String inputMetadata,
+  ) async {
+    return await promiseToFuture(_resolveDID(
+      did,
+      inputMetadata,
+    ));
   }
 
   @override
-  String dereferenceDIDURL(String didUrl, String inputMetadata) {
-    return DIDKitJS.dereferenceDIDURL(didUrl, inputMetadata);
+  Future<String> dereferenceDIDURL(
+    String didUrl,
+    String inputMetadata,
+  ) async {
+    return await promiseToFuture(_dereferenceDIDURL(
+      didUrl,
+      inputMetadata,
+    ));
+  }
+
+  @override
+  Future<String> DIDAuth(
+    String did,
+    String options,
+    String key,
+  ) async {
+    return await promiseToFuture(_DIDAuth(
+      did,
+      options,
+      key,
+    ));
   }
 }

--- a/lib/app/pages/profile/profile.dart
+++ b/lib/app/pages/profile/profile.dart
@@ -8,7 +8,6 @@ import 'package:credible/app/shared/palette.dart';
 import 'package:credible/app/shared/widget/base/page.dart';
 import 'package:credible/app/shared/widget/info_dialog.dart';
 import 'package:credible/app/shared/widget/navigation_bar.dart';
-import 'package:credible/localizations.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';


### PR DESCRIPTION
Fixes DIDKit provider interface to use Futures/Promises in methods where that is required for the Web target.