### PR TITLE
Misc build fixes

### DIFF
--- a/lib/app/pages/profile/profile.dart
+++ b/lib/app/pages/profile/profile.dart
@@ -76,23 +76,23 @@ class _ProfilePageState extends State<ProfilePage> {
                   ),
                 ),
               const SizedBox(height: 32.0),
-              MenuItem(
+              MyMenuItem(
                 icon: Icons.person,
                 title: localizations.personalTitle,
                 onTap: () =>
                     Modular.to.pushNamed('/profile/personal', arguments: model),
               ),
-              MenuItem(
+              MyMenuItem(
                 icon: Icons.shield,
                 title: localizations.privacyTitle,
                 onTap: () => Modular.to.pushNamed('/profile/privacy'),
               ),
-              MenuItem(
+              MyMenuItem(
                 icon: Icons.article,
                 title: localizations.onBoardingTosTitle,
                 onTap: () => Modular.to.pushNamed('/profile/terms'),
               ),
-              MenuItem(
+              MyMenuItem(
                 icon: Icons.vpn_key,
                 title: localizations.recoveryTitle,
                 onTap: () async {
@@ -112,12 +112,12 @@ class _ProfilePageState extends State<ProfilePage> {
                   }
                 },
               ),
-              MenuItem(
+              MyMenuItem(
                 icon: Icons.support,
                 title: localizations.supportTitle,
                 onTap: () => Modular.to.pushNamed('/profile/support'),
               ),
-              MenuItem(
+              MyMenuItem(
                 icon: Icons.assignment_sharp,
                 title: localizations.noticesTitle,
                 onTap: () => Modular.to.pushNamed('/profile/notices'),

--- a/lib/app/pages/profile/widgets/menu_item.dart
+++ b/lib/app/pages/profile/widgets/menu_item.dart
@@ -1,12 +1,12 @@
 import 'package:credible/app/shared/ui/ui.dart';
 import 'package:flutter/material.dart';
 
-class MenuItem extends StatelessWidget {
+class MyMenuItem extends StatelessWidget {
   final IconData icon;
   final String title;
   final VoidCallback onTap;
 
-  const MenuItem({
+  const MyMenuItem({
     Key? key,
     required this.icon,
     required this.title,

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -14,7 +14,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.8.2"
+    version: "2.9.0"
   bip39:
     dependency: "direct main"
     description:
@@ -44,7 +44,7 @@ packages:
       name: characters
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.2.1"
   charcode:
     dependency: transitive
     description:
@@ -65,7 +65,7 @@ packages:
       name: collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.15.0"
+    version: "1.16.0"
   convert:
     dependency: transitive
     description:
@@ -114,7 +114,7 @@ packages:
       name: fake_async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.0"
   ffi:
     dependency: transitive
     description:
@@ -159,7 +159,7 @@ packages:
       name: flutter_modular
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.5.1+1"
+    version: "5.0.2"
   flutter_modular_annotations:
     dependency: transitive
     description:
@@ -288,7 +288,7 @@ packages:
       name: js
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.6.3"
+    version: "0.6.4"
   local_auth:
     dependency: "direct main"
     description:
@@ -323,28 +323,28 @@ packages:
       name: material_color_utilities
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.3"
+    version: "0.1.5"
   meta:
     dependency: transitive
     description:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.7.0"
+    version: "1.8.0"
   modular_core:
     dependency: transitive
     description:
       name: modular_core
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.2"
+    version: "2.0.3+1"
   modular_interfaces:
     dependency: transitive
     description:
       name: modular_interfaces
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.4"
+    version: "2.0.2"
   nested:
     dependency: transitive
     description:
@@ -400,7 +400,7 @@ packages:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0"
+    version: "1.8.2"
   path_drawing:
     dependency: transitive
     description:
@@ -636,7 +636,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.1"
+    version: "1.9.0"
   stack_trace:
     dependency: transitive
     description:
@@ -657,7 +657,7 @@ packages:
       name: string_scanner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.1.1"
   synchronized:
     dependency: transitive
     description:
@@ -678,14 +678,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.8"
-  triple:
-    dependency: transitive
-    description:
-      name: triple
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.5.0+1"
+    version: "0.4.9"
   typed_data:
     dependency: transitive
     description:
@@ -762,7 +755,7 @@ packages:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.2"
   win32:
     dependency: transitive
     description:
@@ -785,5 +778,5 @@ packages:
     source: hosted
     version: "5.3.1"
 sdks:
-  dart: ">=2.16.1 <3.0.0"
+  dart: ">=2.17.0-0 <3.0.0"
   flutter: ">=2.10.0"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -533,7 +533,7 @@ packages:
       name: qr_code_scanner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.7.0"
+    version: "1.0.0"
   qr_flutter:
     dependency: "direct main"
     description:
@@ -778,5 +778,5 @@ packages:
     source: hosted
     version: "5.3.1"
 sdks:
-  dart: ">=2.17.0-0 <3.0.0"
+  dart: ">=2.17.0 <3.0.0"
   flutter: ">=2.10.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,7 +15,7 @@ dependencies:
     sdk: flutter
   intl: ^0.17.0
 
-  flutter_modular: ^4.5.1+1
+  flutter_modular: ^5.0.2
   flutter_bloc: ^8.0.1
   bloc: ^8.0.3
   rxdart: ^0.26.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -32,7 +32,7 @@ dependencies:
   cupertino_icons: ^1.0.4
 
   qr_flutter: ^4.0.0
-  qr_code_scanner: ^0.7.0
+  qr_code_scanner: ^1.0.0
 
   path: ^1.8.0
   path_provider: ^2.0.9


### PR DESCRIPTION
Renaming MenuItem is to avoid the following error:
```
Error: 'MenuItem' is imported from both 'package:credible/app/pages/profile/widgets/menu_item.dart' and 'package:flutter/src/widgets/platform_menu_bar.dart'.
```

Updating `qr_code_scanner` and `flutter_modular` is to fix various errors coming from those packages.